### PR TITLE
fix: issue printing destructured tag params

### DIFF
--- a/src/__tests__/__snapshots__/params-destructured.expected/auto.marko
+++ b/src/__tests__/__snapshots__/params-destructured.expected/auto.marko
@@ -1,0 +1,11 @@
+<macro name="recursive">
+  <await(generator.next())>
+    <@then|{ value, done }|>
+      <div>
+        <ul><li>${value}</li></ul>
+        <ul><li>${value}</li></ul>
+        <ul><li>${value}</li></ul>
+      </div>
+    </@then>
+  </await>
+</macro>

--- a/src/__tests__/__snapshots__/params-destructured.expected/concise.marko
+++ b/src/__tests__/__snapshots__/params-destructured.expected/concise.marko
@@ -1,0 +1,10 @@
+macro name="recursive"
+  await(generator.next())
+    @then|{ value, done }|
+      div
+        ul
+          li -- ${value}
+        ul
+          li -- ${value}
+        ul
+          li -- ${value}

--- a/src/__tests__/__snapshots__/params-destructured.expected/html.marko
+++ b/src/__tests__/__snapshots__/params-destructured.expected/html.marko
@@ -1,0 +1,11 @@
+<macro name="recursive">
+  <await(generator.next())>
+    <@then|{ value, done }|>
+      <div>
+        <ul><li>${value}</li></ul>
+        <ul><li>${value}</li></ul>
+        <ul><li>${value}</li></ul>
+      </div>
+    </@then>
+  </await>
+</macro>

--- a/src/__tests__/__snapshots__/params-destructured.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/params-destructured.expected/with-parens.marko
@@ -1,0 +1,11 @@
+<macro name="recursive">
+  <await(generator.next())>
+    <@then|{ value, done }|>
+      <div>
+        <ul><li>${value}</li></ul>
+        <ul><li>${value}</li></ul>
+        <ul><li>${value}</li></ul>
+      </div>
+    </@then>
+  </await>
+</macro>

--- a/src/__tests__/fixtures/params-destructured.marko
+++ b/src/__tests__/fixtures/params-destructured.marko
@@ -1,0 +1,11 @@
+<macro name="recursive">
+  <await(generator.next())>
+    <@then|{ value, done }|>
+      <div>
+        <ul><li>${value}</li></ul>
+        <ul><li>${value}</li></ul>
+        <ul><li>${value}</li></ul>
+      </div>
+    </@then>
+  </await>
+</macro>

--- a/src/index.ts
+++ b/src/index.ts
@@ -600,8 +600,11 @@ export const printers: Record<string, Printer<Node>> = {
                 "__js_expression",
                 (doc: any) => {
                   const { contents } = doc.contents[0];
-                  if (Array.isArray(contents) && contents[0] === "(") {
-                    return contents.slice(1, -1);
+                  if (Array.isArray(contents) && contents[0].startsWith("(")) {
+                    contents[0] = contents[0].slice(1);
+                    contents[contents.length - 1] = contents[
+                      contents.length - 1
+                    ].slice(0, -1);
                   }
 
                   return contents;


### PR DESCRIPTION
## Description

Fixes an issue where tag parameters (when destructured) were printed with additional parenthesis.

## Motivation and Context

fixes #1

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
