### PR TITLE
fix: issue with parens not added when necessary

### DIFF
--- a/src/__tests__/__snapshots__/attr-conditional-expression.expected/auto.marko
+++ b/src/__tests__/__snapshots__/attr-conditional-expression.expected/auto.marko
@@ -1,1 +1,1 @@
-<div data-foo=(a ? b : c) data-bar=(a ? b : c)/>
+<div data-foo=a ? b : c data-bar=a ? b : c/>

--- a/src/__tests__/__snapshots__/attr-conditional-expression.expected/concise.marko
+++ b/src/__tests__/__snapshots__/attr-conditional-expression.expected/concise.marko
@@ -1,1 +1,1 @@
-div data-foo=(a ? b : c) data-bar=(a ? b : c)
+div data-foo=a ? b : c data-bar=a ? b : c

--- a/src/__tests__/__snapshots__/attr-conditional-expression.expected/html.marko
+++ b/src/__tests__/__snapshots__/attr-conditional-expression.expected/html.marko
@@ -1,1 +1,1 @@
-<div data-foo=(a ? b : c) data-bar=(a ? b : c)/>
+<div data-foo=a ? b : c data-bar=a ? b : c/>

--- a/src/__tests__/__snapshots__/attr-newline-require-parens.expected/auto.marko
+++ b/src/__tests__/__snapshots__/attr-newline-require-parens.expected/auto.marko
@@ -1,0 +1,4 @@
+meta content=(
+  "https://test.image.com/really/long/url/that/will/infact/cause/the/concat/to/break" +
+  encodeURIComponent("image.jpg").replace("'", "%27")
+)

--- a/src/__tests__/__snapshots__/attr-newline-require-parens.expected/concise.marko
+++ b/src/__tests__/__snapshots__/attr-newline-require-parens.expected/concise.marko
@@ -1,0 +1,4 @@
+meta content=(
+  "https://test.image.com/really/long/url/that/will/infact/cause/the/concat/to/break" +
+  encodeURIComponent("image.jpg").replace("'", "%27")
+)

--- a/src/__tests__/__snapshots__/attr-newline-require-parens.expected/html.marko
+++ b/src/__tests__/__snapshots__/attr-newline-require-parens.expected/html.marko
@@ -1,0 +1,4 @@
+<meta content=(
+  "https://test.image.com/really/long/url/that/will/infact/cause/the/concat/to/break" +
+  encodeURIComponent("image.jpg").replace("'", "%27")
+)>

--- a/src/__tests__/__snapshots__/attr-newline-require-parens.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/attr-newline-require-parens.expected/with-parens.marko
@@ -1,0 +1,4 @@
+meta content=(
+  "https://test.image.com/really/long/url/that/will/infact/cause/the/concat/to/break" +
+  encodeURIComponent("image.jpg").replace("'", "%27")
+)

--- a/src/__tests__/fixtures/attr-newline-require-parens.marko
+++ b/src/__tests__/fixtures/attr-newline-require-parens.marko
@@ -1,0 +1,6 @@
+meta [
+  content=(
+    "https://test.image.com/really/long/url/that/will/infact/cause/the/concat/to/break" +
+    encodeURIComponent("image.jpg").replace("'", "%27")
+  )
+]

--- a/src/utils/outer-code-matches.ts
+++ b/src/utils/outer-code-matches.ts
@@ -77,12 +77,13 @@ enclosedPatterns.push(
 const unenclosedPatterns: Pattern[] = [
   {
     // Word operators
-    match: /(?<=\b)\s*(?:as|in(?:stanceof)?|new|void|delete|keyof|typeof)\s+/y,
+    match:
+      /(?<=\b)[ \t]*(?:as|in(?:stanceof)?|new|void|delete|keyof|typeof)[ \t]+/y,
   },
   {
     // Symbol operators
     match:
-      /\s*(?:[\^~%!]|\+{1,2}|\*{1,2}|-(?:-(?!\s))?|&{1,2}|\|{1,2}|!={0,2}|===?|<{2,3}|>{2,3}|<=?|>=)\s*/y,
+      /[ \t]*(?:[\^~%!]|\+{1,2}|\*{1,2}|-(?:-(?!\s))?|&{1,2}|\|{1,2}|!={0,2}|===?|<{2,3}|>{2,3}|<=?|>=)[ \t]*/y,
   },
 ].concat(enclosedPatterns);
 

--- a/src/utils/with-parens-if-needed.ts
+++ b/src/utils/with-parens-if-needed.ts
@@ -9,18 +9,23 @@ export default function withParensIfNeeded(
   opts: ParserOptions,
   valDoc: Doc
 ) {
+  if (enclosedNodeTypeReg.test(node.type)) return valDoc;
+  const { formatted } = doc.printer.printDocToString(valDoc, {
+    ...opts,
+    printWidth: 0,
+  });
   if (
-    !enclosedNodeTypeReg.test(node.type) &&
-    outerCodeMatches(
-      doc.printer.printDocToString(valDoc, {
-        ...opts,
-        printWidth: 0,
-      }).formatted,
-      /\s|>/y,
-      opts.markoAttrParen
-    )
+    opts.markoAttrParen
+      ? outerCodeMatches(formatted, /\s|>/y, true)
+      : outerCodeMatches(formatted, />/y, false)
   ) {
     return ["(", b.indent([b.softline, valDoc]), b.softline, ")"];
+  } else if (outerCodeMatches(formatted, /\n/y, false)) {
+    return [
+      b.ifBreak("("),
+      b.indent([b.softline, valDoc]),
+      b.ifBreak([b.softline, ")"]),
+    ];
   }
 
   return valDoc;


### PR DESCRIPTION
## Description

This PR fixes an issue where parens were incorrectly omitted for some attribute expressions and unnecessarily included in some others.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
