### PR TITLE
fix: refactor the way classes are formatted to account for shorthand

### DIFF
--- a/src/__tests__/__snapshots__/class-attr-and-shorthand.expected/auto.marko
+++ b/src/__tests__/__snapshots__/class-attr-and-shorthand.expected/auto.marko
@@ -1,0 +1,26 @@
+<div.string.blue/>
+<div.blue.string_list/>
+
+<div.templatestring class=`${blue}`/>
+<div.templatestring_list class=`${blue}`/>
+
+<div.dynamic class=blue/>
+<div.dynamic_list class=blue/>
+
+<div.red.green.mixed_list class=[blue, yellow]/>
+<div.long_list class=[
+  red,
+  yellow,
+  (() => "blue")(),
+  orange,
+...colorList.map((item) => item.color),
+  green
+]/>
+<div.long_item class=(
+  ["red", "orange", "yellow", "green", "blue", "indigo", "violet"]
+    .filter((color) => color.indexOf("e") >= 0)
+    .map((color) => color.toUpperCase())
+)/>
+
+<div.red.multiple.blue/>
+<div.multiple.red.blue/>

--- a/src/__tests__/__snapshots__/class-attr-and-shorthand.expected/concise.marko
+++ b/src/__tests__/__snapshots__/class-attr-and-shorthand.expected/concise.marko
@@ -1,0 +1,26 @@
+div.string.blue
+div.blue.string_list
+
+div.templatestring class=`${blue}`
+div.templatestring_list class=`${blue}`
+
+div.dynamic class=blue
+div.dynamic_list class=blue
+
+div.red.green.mixed_list class=[blue, yellow]
+div.long_list class=[
+  red,
+  yellow,
+  (() => "blue")(),
+  orange,
+...colorList.map((item) => item.color),
+  green
+]
+div.long_item class=(
+  ["red", "orange", "yellow", "green", "blue", "indigo", "violet"]
+    .filter((color) => color.indexOf("e") >= 0)
+    .map((color) => color.toUpperCase())
+)
+
+div.red.multiple.blue
+div.multiple.red.blue

--- a/src/__tests__/__snapshots__/class-attr-and-shorthand.expected/html.marko
+++ b/src/__tests__/__snapshots__/class-attr-and-shorthand.expected/html.marko
@@ -1,0 +1,26 @@
+<div.string.blue/>
+<div.blue.string_list/>
+
+<div.templatestring class=`${blue}`/>
+<div.templatestring_list class=`${blue}`/>
+
+<div.dynamic class=blue/>
+<div.dynamic_list class=blue/>
+
+<div.red.green.mixed_list class=[blue, yellow]/>
+<div.long_list class=[
+  red,
+  yellow,
+  (() => "blue")(),
+  orange,
+...colorList.map((item) => item.color),
+  green
+]/>
+<div.long_item class=(
+  ["red", "orange", "yellow", "green", "blue", "indigo", "violet"]
+    .filter((color) => color.indexOf("e") >= 0)
+    .map((color) => color.toUpperCase())
+)/>
+
+<div.red.multiple.blue/>
+<div.multiple.red.blue/>

--- a/src/__tests__/__snapshots__/class-attr-and-shorthand.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/class-attr-and-shorthand.expected/with-parens.marko
@@ -1,0 +1,26 @@
+<div.string.blue/>
+<div.blue.string_list/>
+
+<div.templatestring class=`${blue}`/>
+<div.templatestring_list class=`${blue}`/>
+
+<div.dynamic class=blue/>
+<div.dynamic_list class=blue/>
+
+<div.red.green.mixed_list class=[blue, yellow]/>
+<div.long_list class=[
+  red,
+  yellow,
+  (() => "blue")(),
+  orange,
+...colorList.map((item) => item.color),
+  green
+]/>
+<div.long_item class=(
+  ["red", "orange", "yellow", "green", "blue", "indigo", "violet"]
+    .filter((color) => color.indexOf("e") >= 0)
+    .map((color) => color.toUpperCase())
+)/>
+
+<div.red.multiple.blue/>
+<div.multiple.red.blue/>

--- a/src/__tests__/__snapshots__/something-wrong.expected/auto.marko
+++ b/src/__tests__/__snapshots__/something-wrong.expected/auto.marko
@@ -9,13 +9,12 @@ class {
 $ var count = state.count;
 
 <div.click-count>
-  <div class=[
-    "count",
+  <div.count class=(
     {
       positive: count > 0,
       negative: count < 0,
-    },
-  ]>
+    }
+  )>
     ${count}
   </div>
   <button on-click("increment", -1)>-1</button>

--- a/src/__tests__/__snapshots__/something-wrong.expected/concise.marko
+++ b/src/__tests__/__snapshots__/something-wrong.expected/concise.marko
@@ -9,13 +9,12 @@ class {
 $ var count = state.count;
 
 div.click-count
-  div class=[
-    "count",
+  div.count class=(
     {
       positive: count > 0,
       negative: count < 0,
-    },
-  ]
+    }
+  )
     -- ${count}
   button on-click("increment", -1) -- -1
   button on-click("increment", 1) -- +1

--- a/src/__tests__/__snapshots__/something-wrong.expected/html.marko
+++ b/src/__tests__/__snapshots__/something-wrong.expected/html.marko
@@ -9,13 +9,12 @@ class {
 $ var count = state.count;
 
 <div.click-count>
-  <div class=[
-    "count",
+  <div.count class=(
     {
       positive: count > 0,
       negative: count < 0,
-    },
-  ]>
+    }
+  )>
     ${count}
   </div>
   <button on-click("increment", -1)>-1</button>

--- a/src/__tests__/__snapshots__/something-wrong.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/something-wrong.expected/with-parens.marko
@@ -9,13 +9,12 @@ class {
 $ var count = state.count;
 
 <div.click-count>
-  <div class=[
-    "count",
+  <div.count class=(
     {
       positive: count > 0,
       negative: count < 0,
-    },
-  ]>
+    }
+  )>
     ${count}
   </div>
   <button on-click("increment", -1)>-1</button>

--- a/src/__tests__/fixtures/class-attr-and-shorthand.marko
+++ b/src/__tests__/fixtures/class-attr-and-shorthand.marko
@@ -1,0 +1,15 @@
+<div.string class="blue"/>
+<div.string_list class=["blue"]/>
+
+<div.templatestring class=`${blue}`/>
+<div.templatestring_list class=[`${blue}`]/>
+
+<div.dynamic class=blue/>
+<div.dynamic_list class=[blue]/>
+
+<div.mixed_list class=["red", blue, "green", yellow]/>
+<div.long_list class=[red, yellow, (() => "blue")(), orange, ...colorList.map((item) => item.color), green]/>
+<div.long_item class=["red", "orange", "yellow", "green", "blue", "indigo", "violet"].filter((color) => color.indexOf('e') >= 0).map((color) => color.toUpperCase())/>
+
+<div.multiple class=["red"] class="blue" />
+<div.multiple class="red" class=["blue"] />


### PR DESCRIPTION
## Motivation and Context

 - Fixes #15 

## Description

- Refactored the way that classes and ids are handled by plugin
- Decisions made for this PR:
  - Class names are auto-shorthanded when they are string literals which are never dynamic, immediately after the class keyword or in an array.
  - Class lists of length 1 are automatically converted to atoms

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
