### PR TITLE
feat: prefer longform class/id in html mode

### DIFF
--- a/src/__tests__/__snapshots__/attr-newline-nested.expected/auto.marko
+++ b/src/__tests__/__snapshots__/attr-newline-nested.expected/auto.marko
@@ -1,12 +1,18 @@
 <div style={
   "background-color": imageCreative.contentBackgroundColor,
 }>
-  <div.test style={
-    "background-color": imageCreative.contentBackgroundColor,
-  }>
-    <div.test style={
+  <div
+    class="test"
+    style={
       "background-color": imageCreative.contentBackgroundColor,
-    }>
+    }
+  >
+    <div
+      class="test"
+      style={
+        "background-color": imageCreative.contentBackgroundColor,
+      }
+    >
       <div style={
         "background-color": imageCreative.contentBackgroundColor,
       }/>

--- a/src/__tests__/__snapshots__/attr-newline-nested.expected/html.marko
+++ b/src/__tests__/__snapshots__/attr-newline-nested.expected/html.marko
@@ -1,12 +1,18 @@
 <div style={
   "background-color": imageCreative.contentBackgroundColor,
 }>
-  <div.test style={
-    "background-color": imageCreative.contentBackgroundColor,
-  }>
-    <div.test style={
+  <div
+    class="test"
+    style={
       "background-color": imageCreative.contentBackgroundColor,
-    }>
+    }
+  >
+    <div
+      class="test"
+      style={
+        "background-color": imageCreative.contentBackgroundColor,
+      }
+    >
       <div style={
         "background-color": imageCreative.contentBackgroundColor,
       }/>

--- a/src/__tests__/__snapshots__/attr-newline-nested.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/attr-newline-nested.expected/with-parens.marko
@@ -1,12 +1,18 @@
 <div style={
   "background-color": imageCreative.contentBackgroundColor,
 }>
-  <div.test style={
-    "background-color": imageCreative.contentBackgroundColor,
-  }>
-    <div.test style={
+  <div
+    class="test"
+    style={
       "background-color": imageCreative.contentBackgroundColor,
-    }>
+    }
+  >
+    <div
+      class="test"
+      style={
+        "background-color": imageCreative.contentBackgroundColor,
+      }
+    >
       <div style={
         "background-color": imageCreative.contentBackgroundColor,
       }/>

--- a/src/__tests__/__snapshots__/attr-short.expected/auto.marko
+++ b/src/__tests__/__snapshots__/attr-short.expected/auto.marko
@@ -1,1 +1,1 @@
-<custom-tag#hello/>
+<custom-tag id="hello"/>

--- a/src/__tests__/__snapshots__/attr-short.expected/html.marko
+++ b/src/__tests__/__snapshots__/attr-short.expected/html.marko
@@ -1,1 +1,1 @@
-<custom-tag#hello/>
+<custom-tag id="hello"/>

--- a/src/__tests__/__snapshots__/attr-short.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/attr-short.expected/with-parens.marko
@@ -1,1 +1,1 @@
-<custom-tag#hello/>
+<custom-tag id="hello"/>

--- a/src/__tests__/__snapshots__/attr-with-comment-short.expected/auto.marko
+++ b/src/__tests__/__snapshots__/attr-with-comment-short.expected/auto.marko
@@ -1,4 +1,4 @@
-<custom-tag#hello/>
+<custom-tag id="hello"/>
 <!-- <custom-tag
   id="hello" // this comment is currently not supported
 /> -->

--- a/src/__tests__/__snapshots__/attr-with-comment-short.expected/html.marko
+++ b/src/__tests__/__snapshots__/attr-with-comment-short.expected/html.marko
@@ -1,4 +1,4 @@
-<custom-tag#hello/>
+<custom-tag id="hello"/>
 <!-- <custom-tag
   id="hello" // this comment is currently not supported
 /> -->

--- a/src/__tests__/__snapshots__/attr-with-comment-short.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/attr-with-comment-short.expected/with-parens.marko
@@ -1,4 +1,4 @@
-<custom-tag#hello/>
+<custom-tag id="hello"/>
 <!-- <custom-tag
   id="hello" // this comment is currently not supported
 /> -->

--- a/src/__tests__/__snapshots__/attrs-multiline-nested.expected/auto.marko
+++ b/src/__tests__/__snapshots__/attrs-multiline-nested.expected/auto.marko
@@ -1,15 +1,17 @@
-<div.my-class
+<div
   data-foo="foo"
   data-bar="bar"
   data-hello="hello"
   data-world="world"
+  class="my-class"
   data-widget="my-really-awesome-weidget"
 >
-  <div.my-class
+  <div
     data-foo="foo"
     data-bar="bar"
     data-hello="hello"
     data-world="world"
+    class="my-class"
     data-widget="my-really-awesome-weidget"
   >
     Hello World

--- a/src/__tests__/__snapshots__/attrs-multiline-nested.expected/html.marko
+++ b/src/__tests__/__snapshots__/attrs-multiline-nested.expected/html.marko
@@ -1,15 +1,17 @@
-<div.my-class
+<div
   data-foo="foo"
   data-bar="bar"
   data-hello="hello"
   data-world="world"
+  class="my-class"
   data-widget="my-really-awesome-weidget"
 >
-  <div.my-class
+  <div
     data-foo="foo"
     data-bar="bar"
     data-hello="hello"
     data-world="world"
+    class="my-class"
     data-widget="my-really-awesome-weidget"
   >
     Hello World

--- a/src/__tests__/__snapshots__/attrs-multiline-nested.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/attrs-multiline-nested.expected/with-parens.marko
@@ -1,15 +1,17 @@
-<div.my-class
+<div
   data-foo="foo"
   data-bar="bar"
   data-hello="hello"
   data-world="world"
+  class="my-class"
   data-widget="my-really-awesome-weidget"
 >
-  <div.my-class
+  <div
     data-foo="foo"
     data-bar="bar"
     data-hello="hello"
     data-world="world"
+    class="my-class"
     data-widget="my-really-awesome-weidget"
   >
     Hello World

--- a/src/__tests__/__snapshots__/attrs-multiline.expected/auto.marko
+++ b/src/__tests__/__snapshots__/attrs-multiline.expected/auto.marko
@@ -1,8 +1,9 @@
-<div.my-class
+<div
   data-foo="foo"
   data-bar="bar"
   data-hello="hello"
   data-world="world"
+  class="my-class"
   data-widget="my-really-awesome-weidget"
 >
   Hello World

--- a/src/__tests__/__snapshots__/attrs-multiline.expected/html.marko
+++ b/src/__tests__/__snapshots__/attrs-multiline.expected/html.marko
@@ -1,8 +1,9 @@
-<div.my-class
+<div
   data-foo="foo"
   data-bar="bar"
   data-hello="hello"
   data-world="world"
+  class="my-class"
   data-widget="my-really-awesome-weidget"
 >
   Hello World

--- a/src/__tests__/__snapshots__/attrs-multiline.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/attrs-multiline.expected/with-parens.marko
@@ -1,8 +1,9 @@
-<div.my-class
+<div
   data-foo="foo"
   data-bar="bar"
   data-hello="hello"
   data-world="world"
+  class="my-class"
   data-widget="my-really-awesome-weidget"
 >
   Hello World

--- a/src/__tests__/__snapshots__/comments-inline-complex.expected/html.marko
+++ b/src/__tests__/__snapshots__/comments-inline-complex.expected/html.marko
@@ -1,4 +1,4 @@
-<div.hello>
+<div class="hello">
   // This is a line comment
 
   <span>Welcome to <b>Marko</b></span>

--- a/src/__tests__/__snapshots__/comments.expected/html.marko
+++ b/src/__tests__/__snapshots__/comments.expected/html.marko
@@ -1,4 +1,4 @@
-<div.hello>
+<div class="hello">
   // This is a line comment
 
   <span>Welcome to <b>Marko</b></span>

--- a/src/__tests__/__snapshots__/formating-tags-multiline.expected/html.marko
+++ b/src/__tests__/__snapshots__/formating-tags-multiline.expected/html.marko
@@ -1,1 +1,3 @@
-<div.hello><span>Welcome to the wonderful world of <b>Marko</b></span></div>
+<div class="hello">
+  <span>Welcome to the wonderful world of <b>Marko</b></span>
+</div>

--- a/src/__tests__/__snapshots__/formating-tags-single-line.expected/html.marko
+++ b/src/__tests__/__snapshots__/formating-tags-single-line.expected/html.marko
@@ -1,1 +1,1 @@
-<div.hello><span>Welcome to the <b>Marko</b></span></div>
+<div class="hello"><span>Welcome to the <b>Marko</b></span></div>

--- a/src/__tests__/__snapshots__/max-line-length.expected/auto.marko
+++ b/src/__tests__/__snapshots__/max-line-length.expected/auto.marko
@@ -4,8 +4,9 @@
     <title>Marko Templating Engine</title>
   </head>
   <body>
-    <h1.super-duper-long__class-name>Hello ${data.name}!</h1>
-    <h2.super-duper-long__class-name
+    <h1 class="super-duper-long__class-name">Hello ${data.name}!</h1>
+    <h2
+      class="super-duper-long__class-name"
       data-test="test attribute data"
       data-more="more attribute data"
       style="display: inline;"

--- a/src/__tests__/__snapshots__/max-line-length.expected/html.marko
+++ b/src/__tests__/__snapshots__/max-line-length.expected/html.marko
@@ -4,8 +4,9 @@
     <title>Marko Templating Engine</title>
   </head>
   <body>
-    <h1.super-duper-long__class-name>Hello ${data.name}!</h1>
-    <h2.super-duper-long__class-name
+    <h1 class="super-duper-long__class-name">Hello ${data.name}!</h1>
+    <h2
+      class="super-duper-long__class-name"
       data-test="test attribute data"
       data-more="more attribute data"
       style="display: inline;"

--- a/src/__tests__/__snapshots__/max-line-length.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/max-line-length.expected/with-parens.marko
@@ -4,8 +4,9 @@
     <title>Marko Templating Engine</title>
   </head>
   <body>
-    <h1.super-duper-long__class-name>Hello ${data.name}!</h1>
-    <h2.super-duper-long__class-name
+    <h1 class="super-duper-long__class-name">Hello ${data.name}!</h1>
+    <h2
+      class="super-duper-long__class-name"
       data-test="test attribute data"
       data-more="more attribute data"
       style="display: inline;"

--- a/src/__tests__/__snapshots__/shorthand-body.expected/html.marko
+++ b/src/__tests__/__snapshots__/shorthand-body.expected/html.marko
@@ -1,1 +1,1 @@
-<div#foo>Hello World</div>
+<div id="foo">Hello World</div>

--- a/src/__tests__/__snapshots__/shorthand-class-multiple.expected/html.marko
+++ b/src/__tests__/__snapshots__/shorthand-class-multiple.expected/html.marko
@@ -1,1 +1,1 @@
-<div.foo.bar/>
+<div class="foo bar"/>

--- a/src/__tests__/__snapshots__/shorthand-class-single.expected/html.marko
+++ b/src/__tests__/__snapshots__/shorthand-class-single.expected/html.marko
@@ -1,1 +1,1 @@
-<div.foo/>
+<div class="foo"/>

--- a/src/__tests__/__snapshots__/shorthand-id-classes.expected/html.marko
+++ b/src/__tests__/__snapshots__/shorthand-id-classes.expected/html.marko
@@ -1,1 +1,1 @@
-<div.bar.baz#foo/>
+<div class="bar baz" id="foo"/>

--- a/src/__tests__/__snapshots__/shorthand-id.expected/html.marko
+++ b/src/__tests__/__snapshots__/shorthand-id.expected/html.marko
@@ -1,1 +1,1 @@
-<div#foo/>
+<div id="foo"/>

--- a/src/__tests__/__snapshots__/something-wrong.expected/auto.marko
+++ b/src/__tests__/__snapshots__/something-wrong.expected/auto.marko
@@ -8,7 +8,7 @@ class {
 }
 $ var count = state.count;
 
-<div.click-count>
+<div class="click-count">
   <div class=[
     "count",
     {

--- a/src/__tests__/__snapshots__/something-wrong.expected/html.marko
+++ b/src/__tests__/__snapshots__/something-wrong.expected/html.marko
@@ -8,7 +8,7 @@ class {
 }
 $ var count = state.count;
 
-<div.click-count>
+<div class="click-count">
   <div class=[
     "count",
     {

--- a/src/__tests__/__snapshots__/something-wrong.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/something-wrong.expected/with-parens.marko
@@ -8,7 +8,7 @@ class {
 }
 $ var count = state.count;
 
-<div.click-count>
+<div class="click-count">
   <div class=[
     "count",
     {

--- a/src/__tests__/__snapshots__/static-function.expected/auto.marko
+++ b/src/__tests__/__snapshots__/static-function.expected/auto.marko
@@ -6,18 +6,18 @@ static function getAnchorName(section) {
   return section.anchorName;
 }
 
-<div.app-sections>
-  <div.tableOfContents>
+<div class="app-sections">
+  <div class="tableOfContents">
     <ul>
       <li for(section in data.sections)>
         <a href="#${getAnchorName(section)}">${section.title}</a>
       </li>
     </ul>
   </div>
-  <div.sections-ctr>
-    <div.section for(section in data.sections)>
+  <div class="sections-ctr">
+    <div class="section" for(section in data.sections)>
       <h2 id=getAnchorName(section)>${section.title}</h2>
-      <div.section-body><include(section)/></div>
+      <div class="section-body"><include(section)/></div>
     </div>
   </div>
 </div>

--- a/src/__tests__/__snapshots__/static-function.expected/html.marko
+++ b/src/__tests__/__snapshots__/static-function.expected/html.marko
@@ -6,18 +6,18 @@ static function getAnchorName(section) {
   return section.anchorName;
 }
 
-<div.app-sections>
-  <div.tableOfContents>
+<div class="app-sections">
+  <div class="tableOfContents">
     <ul>
       <li for(section in data.sections)>
         <a href="#${getAnchorName(section)}">${section.title}</a>
       </li>
     </ul>
   </div>
-  <div.sections-ctr>
-    <div.section for(section in data.sections)>
+  <div class="sections-ctr">
+    <div class="section" for(section in data.sections)>
       <h2 id=getAnchorName(section)>${section.title}</h2>
-      <div.section-body><include(section)/></div>
+      <div class="section-body"><include(section)/></div>
     </div>
   </div>
 </div>

--- a/src/__tests__/__snapshots__/static-function.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/static-function.expected/with-parens.marko
@@ -6,18 +6,18 @@ static function getAnchorName(section) {
   return section.anchorName;
 }
 
-<div.app-sections>
-  <div.tableOfContents>
+<div class="app-sections">
+  <div class="tableOfContents">
     <ul>
       <li for(section in data.sections)>
         <a href="#${getAnchorName(section)}">${section.title}</a>
       </li>
     </ul>
   </div>
-  <div.sections-ctr>
-    <div.section for(section in data.sections)>
+  <div class="sections-ctr">
+    <div class="section" for(section in data.sections)>
       <h2 id=getAnchorName(section)>${section.title}</h2>
-      <div.section-body><include(section)/></div>
+      <div class="section-body"><include(section)/></div>
     </div>
   </div>
 </div>

--- a/src/__tests__/__snapshots__/var-array.expected/html.marko
+++ b/src/__tests__/__snapshots__/var-array.expected/html.marko
@@ -8,6 +8,6 @@
 />
 
 <app-button ref="button" class=classNames onClick("handleClick")>
-  <span.app-checkbox-icon/>
+  <span class="app-checkbox-icon"/>
   <span ref="checkboxLabel"><include(state.body)/></span>
 </app-button>


### PR DESCRIPTION
## Description

Temporary workaround for #18.
In html mode prefers longform class/id attributes.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
