### PR TITLE
fix: printing marko placeholders in embedded script/styles

### DIFF
--- a/src/__tests__/__snapshots__/embedded-text-with-placeholders.expected/auto.marko
+++ b/src/__tests__/__snapshots__/embedded-text-with-placeholders.expected/auto.marko
@@ -1,0 +1,6 @@
+<script>window.bla = ${JSON.stringify(input.bla)};</script>
+
+<script>
+  window.a = ${JSON.stringify(input.a)};
+  window.b = ${JSON.stringify(input.b)};
+</script>

--- a/src/__tests__/__snapshots__/embedded-text-with-placeholders.expected/concise.marko
+++ b/src/__tests__/__snapshots__/embedded-text-with-placeholders.expected/concise.marko
@@ -1,0 +1,7 @@
+script -- window.bla = ${JSON.stringify(input.bla)};
+
+script
+  --
+  window.a = ${JSON.stringify(input.a)};
+  window.b = ${JSON.stringify(input.b)};
+  --

--- a/src/__tests__/__snapshots__/embedded-text-with-placeholders.expected/html.marko
+++ b/src/__tests__/__snapshots__/embedded-text-with-placeholders.expected/html.marko
@@ -1,0 +1,6 @@
+<script>window.bla = ${JSON.stringify(input.bla)};</script>
+
+<script>
+  window.a = ${JSON.stringify(input.a)};
+  window.b = ${JSON.stringify(input.b)};
+</script>

--- a/src/__tests__/__snapshots__/embedded-text-with-placeholders.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/embedded-text-with-placeholders.expected/with-parens.marko
@@ -1,0 +1,6 @@
+<script>window.bla = ${JSON.stringify(input.bla)};</script>
+
+<script>
+  window.a = ${JSON.stringify(input.a)};
+  window.b = ${JSON.stringify(input.b)};
+</script>

--- a/src/__tests__/__snapshots__/embedded-text-with-placeholders/auto.marko
+++ b/src/__tests__/__snapshots__/embedded-text-with-placeholders/auto.marko
@@ -1,0 +1,1 @@
+<script>window.bla = ${JSON.stringify(input.bla)};</script>

--- a/src/__tests__/__snapshots__/embedded-text-with-placeholders/concise.marko
+++ b/src/__tests__/__snapshots__/embedded-text-with-placeholders/concise.marko
@@ -1,0 +1,1 @@
+script -- window.bla = ${JSON.stringify(input.bla)};

--- a/src/__tests__/__snapshots__/embedded-text-with-placeholders/html.marko
+++ b/src/__tests__/__snapshots__/embedded-text-with-placeholders/html.marko
@@ -1,0 +1,1 @@
+<script>window.bla = ${JSON.stringify(input.bla)};</script>

--- a/src/__tests__/__snapshots__/embedded-text-with-placeholders/with-parens.marko
+++ b/src/__tests__/__snapshots__/embedded-text-with-placeholders/with-parens.marko
@@ -1,0 +1,1 @@
+<script>window.bla = ${JSON.stringify(input.bla)};</script>

--- a/src/__tests__/fixtures/embedded-text-with-placeholders.marko
+++ b/src/__tests__/fixtures/embedded-text-with-placeholders.marko
@@ -1,0 +1,8 @@
+<script>
+    window.bla = ${JSON.stringify(input.bla)};
+</script>
+
+<script>
+    window.a = ${JSON.stringify(input.a)};
+    window.b = ${JSON.stringify(input.b)};
+</script>


### PR DESCRIPTION
## Description

Fixes formatting embedded code (`script`/`style`) with Marko placeholders.

eg

```marko
<script>window.x = ${input.value}</script>
```

resolves #21 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
