### PR TITLE
fix(scriptlet): remove trim from tryPrintEmbed

### DIFF
--- a/src/__tests__/__snapshots__/ignore-embedded-script-errors.expected/auto.marko
+++ b/src/__tests__/__snapshots__/ignore-embedded-script-errors.expected/auto.marko
@@ -1,18 +1,18 @@
 style {
-
+  
   invalid { color blue; }
 
 }
 
 <style>
-
+  
   body 
       color: blue;
 
 </style>
 
 <script>
-
+  
   console->log(
   'a'
   );

--- a/src/__tests__/__snapshots__/ignore-embedded-script-errors.expected/concise.marko
+++ b/src/__tests__/__snapshots__/ignore-embedded-script-errors.expected/concise.marko
@@ -1,12 +1,12 @@
 style {
-
+  
   invalid { color blue; }
 
 }
 
 style
   --
-
+  
   body 
       color: blue;
 
@@ -14,7 +14,7 @@ style
 
 script
   --
-
+  
   console->log(
   'a'
   );

--- a/src/__tests__/__snapshots__/ignore-embedded-script-errors.expected/html.marko
+++ b/src/__tests__/__snapshots__/ignore-embedded-script-errors.expected/html.marko
@@ -1,18 +1,18 @@
 style {
-
+  
   invalid { color blue; }
 
 }
 
 <style>
-
+  
   body 
       color: blue;
 
 </style>
 
 <script>
-
+  
   console->log(
   'a'
   );

--- a/src/__tests__/__snapshots__/ignore-embedded-script-errors.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/ignore-embedded-script-errors.expected/with-parens.marko
@@ -1,18 +1,18 @@
 style {
-
+  
   invalid { color blue; }
 
 }
 
 <style>
-
+  
   body 
       color: blue;
 
 </style>
 
 <script>
-
+  
   console->log(
   'a'
   );

--- a/src/__tests__/__snapshots__/scriptlet-ts.expected/auto.marko
+++ b/src/__tests__/__snapshots__/scriptlet-ts.expected/auto.marko
@@ -1,0 +1,10 @@
+static const x: number = 3 as const
+static function xPlus(val: number) {
+  return x + val;
+}
+static let xMap = new Map<string, number>()
+$ const y: number = 3 as const
+$ function yPlus(val: number) {
+  return x + val;
+}
+$ let yMap = new Map<string, number>()

--- a/src/__tests__/__snapshots__/scriptlet-ts.expected/concise.marko
+++ b/src/__tests__/__snapshots__/scriptlet-ts.expected/concise.marko
@@ -1,0 +1,10 @@
+static const x: number = 3 as const
+static function xPlus(val: number) {
+  return x + val;
+}
+static let xMap = new Map<string, number>()
+$ const y: number = 3 as const
+$ function yPlus(val: number) {
+  return x + val;
+}
+$ let yMap = new Map<string, number>()

--- a/src/__tests__/__snapshots__/scriptlet-ts.expected/html.marko
+++ b/src/__tests__/__snapshots__/scriptlet-ts.expected/html.marko
@@ -1,0 +1,10 @@
+static const x: number = 3 as const
+static function xPlus(val: number) {
+  return x + val;
+}
+static let xMap = new Map<string, number>()
+$ const y: number = 3 as const
+$ function yPlus(val: number) {
+  return x + val;
+}
+$ let yMap = new Map<string, number>()

--- a/src/__tests__/__snapshots__/scriptlet-ts.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/scriptlet-ts.expected/with-parens.marko
@@ -1,0 +1,10 @@
+static const x: number = 3 as const
+static function xPlus(val: number) {
+  return x + val;
+}
+static let xMap = new Map<string, number>()
+$ const y: number = 3 as const
+$ function yPlus(val: number) {
+  return x + val;
+}
+$ let yMap = new Map<string, number>()

--- a/src/__tests__/fixtures/scriptlet-ts.marko
+++ b/src/__tests__/fixtures/scriptlet-ts.marko
@@ -1,0 +1,7 @@
+static const x: number = 3 as const
+static function xPlus(val: number) { return x + val }
+static let xMap = new Map<string, number>()
+
+$ const y: number = 3 as const
+$ function yPlus(val: number) { return x + val }
+$ let yMap = new Map<string, number>()

--- a/src/index.ts
+++ b/src/index.ts
@@ -750,7 +750,7 @@ export const printers: Record<string, Printer<Node>> = {
             (toDoc as any)(code, { parser }, { stripTrailingHardline: true })
           );
         } catch {
-          return [b.trim, asLiteralTextContent(code)];
+          return [asLiteralTextContent(code)];
         }
       }
     },


### PR DESCRIPTION
- Addresses #28

> **Warning**
> This is only a **partial fix**. It prevents the template from breaking, but the scriptlet body is not formatted as a result.

## Description

Since `normalize` is currently failing for TS scriptlet bodies, we were getting something like this for each of the groups:
```
b.group(["static", " ", b.trim, "const", " ", ...]
```
As a result, the `" "` was always removed out by `b.trim`

## Next Step

Figure out why an error is being thrown in `tryPrintEmbed` for TS scriptlets