### PR TITLE
fix(parser): switch to babel-ts

### DIFF
--- a/src/__tests__/__snapshots__/scriptlet-ts.expected/auto.marko
+++ b/src/__tests__/__snapshots__/scriptlet-ts.expected/auto.marko
@@ -1,10 +1,10 @@
-static const x: number = 3 as const
+static const x: number = 3 as const;
 static function xPlus(val: number) {
   return x + val;
 }
-static let xMap = new Map<string, number>()
-$ const y: number = 3 as const
+static let xMap = new Map<string, number>();
+$ const y: number = 3 as const;
 $ function yPlus(val: number) {
   return x + val;
 }
-$ let yMap = new Map<string, number>()
+$ let yMap = new Map<string, number>();

--- a/src/__tests__/__snapshots__/scriptlet-ts.expected/concise.marko
+++ b/src/__tests__/__snapshots__/scriptlet-ts.expected/concise.marko
@@ -1,10 +1,10 @@
-static const x: number = 3 as const
+static const x: number = 3 as const;
 static function xPlus(val: number) {
   return x + val;
 }
-static let xMap = new Map<string, number>()
-$ const y: number = 3 as const
+static let xMap = new Map<string, number>();
+$ const y: number = 3 as const;
 $ function yPlus(val: number) {
   return x + val;
 }
-$ let yMap = new Map<string, number>()
+$ let yMap = new Map<string, number>();

--- a/src/__tests__/__snapshots__/scriptlet-ts.expected/html.marko
+++ b/src/__tests__/__snapshots__/scriptlet-ts.expected/html.marko
@@ -1,10 +1,10 @@
-static const x: number = 3 as const
+static const x: number = 3 as const;
 static function xPlus(val: number) {
   return x + val;
 }
-static let xMap = new Map<string, number>()
-$ const y: number = 3 as const
+static let xMap = new Map<string, number>();
+$ const y: number = 3 as const;
 $ function yPlus(val: number) {
   return x + val;
 }
-$ let yMap = new Map<string, number>()
+$ let yMap = new Map<string, number>();

--- a/src/__tests__/__snapshots__/scriptlet-ts.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/scriptlet-ts.expected/with-parens.marko
@@ -1,10 +1,10 @@
-static const x: number = 3 as const
+static const x: number = 3 as const;
 static function xPlus(val: number) {
   return x + val;
 }
-static let xMap = new Map<string, number>()
-$ const y: number = 3 as const
+static let xMap = new Map<string, number>();
+$ const y: number = 3 as const;
 $ function yPlus(val: number) {
   return x + val;
 }
-$ let yMap = new Map<string, number>()
+$ let yMap = new Map<string, number>();

--- a/src/__tests__/fixtures/scriptlet-ts.marko
+++ b/src/__tests__/fixtures/scriptlet-ts.marko
@@ -1,7 +1,7 @@
-static const x: number = 3 as const
+static const x:   number = 3   as  const
 static function xPlus(val: number) { return x + val }
-static let xMap = new Map<string, number>()
+static let xMap = new Map<  string , number  >()
 
-$ const y: number = 3 as const
+$ const y : number  = 3 as const
 $ function yPlus(val: number) { return x + val }
-$ let yMap = new Map<string, number>()
+$ let yMap=new Map<string,number>(  )

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,7 @@ export const parsers: Record<string, Parser<Node>> = {
 
       opts.originalText = text;
       opts.markoLinePositions = [0];
-      opts.markoScriptParser = "babel";
+      opts.markoScriptParser = "babel-ts";
       opts.markoPreservingSpace = false;
 
       for (let i = 0; i < text.length; i++) {


### PR DESCRIPTION
Change parser to `babel-ts`, to prevent errors with TypeScript syntax.

Fixes #28 