### PR TITLE
Trailing comma

### DIFF
--- a/src/__tests__/__snapshots__/argument-attr.expected/auto.marko
+++ b/src/__tests__/__snapshots__/argument-attr.expected/auto.marko
@@ -3,7 +3,7 @@
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )/>
 -- ${test}
 

--- a/src/__tests__/__snapshots__/argument-attr.expected/concise.marko
+++ b/src/__tests__/__snapshots__/argument-attr.expected/concise.marko
@@ -3,7 +3,7 @@ div foo(
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )
 -- ${test}
 

--- a/src/__tests__/__snapshots__/argument-attr.expected/html.marko
+++ b/src/__tests__/__snapshots__/argument-attr.expected/html.marko
@@ -3,7 +3,7 @@
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )/>
 -- ${test}
 

--- a/src/__tests__/__snapshots__/argument-attr.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/argument-attr.expected/with-parens.marko
@@ -3,7 +3,7 @@
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )/>
 -- ${test}
 

--- a/src/__tests__/__snapshots__/argument-tag.expected/auto.marko
+++ b/src/__tests__/__snapshots__/argument-tag.expected/auto.marko
@@ -3,6 +3,6 @@
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )/>
 <foo(a, b)/>

--- a/src/__tests__/__snapshots__/argument-tag.expected/concise.marko
+++ b/src/__tests__/__snapshots__/argument-tag.expected/concise.marko
@@ -3,6 +3,6 @@ foo(
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )
 foo(a, b)

--- a/src/__tests__/__snapshots__/argument-tag.expected/html.marko
+++ b/src/__tests__/__snapshots__/argument-tag.expected/html.marko
@@ -3,6 +3,6 @@
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )/>
 <foo(a, b)/>

--- a/src/__tests__/__snapshots__/argument-tag.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/argument-tag.expected/with-parens.marko
@@ -3,6 +3,6 @@
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )/>
 <foo(a, b)/>

--- a/src/__tests__/__snapshots__/attr-with-argument.expected/auto.marko
+++ b/src/__tests__/__snapshots__/attr-with-argument.expected/auto.marko
@@ -3,5 +3,5 @@
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )/>

--- a/src/__tests__/__snapshots__/attr-with-argument.expected/concise.marko
+++ b/src/__tests__/__snapshots__/attr-with-argument.expected/concise.marko
@@ -3,5 +3,5 @@ div foo(
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )

--- a/src/__tests__/__snapshots__/attr-with-argument.expected/html.marko
+++ b/src/__tests__/__snapshots__/attr-with-argument.expected/html.marko
@@ -3,5 +3,5 @@
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )/>

--- a/src/__tests__/__snapshots__/attr-with-argument.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/attr-with-argument.expected/with-parens.marko
@@ -3,5 +3,5 @@
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )/>

--- a/src/__tests__/__snapshots__/if-condition.expected/auto.marko
+++ b/src/__tests__/__snapshots__/if-condition.expected/auto.marko
@@ -1,0 +1,25 @@
+<if(
+  thisPerson.address &&
+  thisPerson.phone &&
+  thisPerson.age &&
+  thisPerson.nationality
+)>
+  <person-card
+    address=thisPerson.address
+    phone=thisPerson.phone
+    age=thisPerson.age
+  />
+</if>
+
+<if(
+  thisPerson.address &&
+  thisPerson.phone &&
+  thisPerson.age &&
+  thisPerson.nationality
+)>
+  <person-card
+    address=thisPerson.address
+    phone=thisPerson.phone
+    age=thisPerson.age
+  />
+</if>

--- a/src/__tests__/__snapshots__/if-condition.expected/concise.marko
+++ b/src/__tests__/__snapshots__/if-condition.expected/concise.marko
@@ -1,0 +1,23 @@
+if(
+  thisPerson.address &&
+  thisPerson.phone &&
+  thisPerson.age &&
+  thisPerson.nationality
+)
+  person-card [
+    address=thisPerson.address
+    phone=thisPerson.phone
+    age=thisPerson.age
+  ]
+
+if(
+  thisPerson.address &&
+  thisPerson.phone &&
+  thisPerson.age &&
+  thisPerson.nationality
+)
+  person-card [
+    address=thisPerson.address
+    phone=thisPerson.phone
+    age=thisPerson.age
+  ]

--- a/src/__tests__/__snapshots__/if-condition.expected/html.marko
+++ b/src/__tests__/__snapshots__/if-condition.expected/html.marko
@@ -1,0 +1,25 @@
+<if(
+  thisPerson.address &&
+  thisPerson.phone &&
+  thisPerson.age &&
+  thisPerson.nationality
+)>
+  <person-card
+    address=thisPerson.address
+    phone=thisPerson.phone
+    age=thisPerson.age
+  />
+</if>
+
+<if(
+  thisPerson.address &&
+  thisPerson.phone &&
+  thisPerson.age &&
+  thisPerson.nationality
+)>
+  <person-card
+    address=thisPerson.address
+    phone=thisPerson.phone
+    age=thisPerson.age
+  />
+</if>

--- a/src/__tests__/__snapshots__/if-condition.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/if-condition.expected/with-parens.marko
@@ -1,0 +1,25 @@
+<if(
+  thisPerson.address &&
+  thisPerson.phone &&
+  thisPerson.age &&
+  thisPerson.nationality
+)>
+  <person-card
+    address=thisPerson.address
+    phone=thisPerson.phone
+    age=thisPerson.age
+  />
+</if>
+
+<if(
+  thisPerson.address &&
+  thisPerson.phone &&
+  thisPerson.age &&
+  thisPerson.nationality
+)>
+  <person-card
+    address=thisPerson.address
+    phone=thisPerson.phone
+    age=thisPerson.age
+  />
+</if>

--- a/src/__tests__/__snapshots__/tag-argument.expected/auto.marko
+++ b/src/__tests__/__snapshots__/tag-argument.expected/auto.marko
@@ -3,5 +3,5 @@
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )/>

--- a/src/__tests__/__snapshots__/tag-argument.expected/concise.marko
+++ b/src/__tests__/__snapshots__/tag-argument.expected/concise.marko
@@ -3,5 +3,5 @@ foo(
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )

--- a/src/__tests__/__snapshots__/tag-argument.expected/html.marko
+++ b/src/__tests__/__snapshots__/tag-argument.expected/html.marko
@@ -3,5 +3,5 @@
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )/>

--- a/src/__tests__/__snapshots__/tag-argument.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/tag-argument.expected/with-parens.marko
@@ -3,5 +3,5 @@
   { aaaaaaaaaa: 1, bbbbbbbbbb: 2, cccccccccc: 3 },
   aaaaaaaaaa,
   bbbbbbbbbb,
-  cccccccccc,
+  cccccccccc
 )/>

--- a/src/__tests__/fixtures/if-condition.marko
+++ b/src/__tests__/fixtures/if-condition.marko
@@ -1,0 +1,20 @@
+<if(thisPerson.address && thisPerson.phone && thisPerson.age && thisPerson.nationality)>
+  <person-card
+    address=thisPerson.address
+    phone=thisPerson.phone
+    age=thisPerson.age
+  />
+</if>
+
+<if(
+  thisPerson.address &&
+  thisPerson.phone &&
+  thisPerson.age &&
+  thisPerson.nationality,
+)>
+  <person-card
+    address=thisPerson.address
+    phone=thisPerson.phone
+    age=thisPerson.age
+  />
+</if>

--- a/src/index.ts
+++ b/src/index.ts
@@ -363,7 +363,7 @@ export const printers: Record<string, Printer<Node>> = {
                     [",", b.line],
                     tagPath.map((it) => print(it), "arguments")
                   ),
-                  opts.trailingComma ? b.ifBreak(",") : "",
+                  opts.trailingComma === "all" ? b.ifBreak(",") : "",
                 ]),
                 b.softline,
                 ")",
@@ -591,7 +591,7 @@ export const printers: Record<string, Printer<Node>> = {
                       [",", b.line],
                       attrPath.map((it) => print(it), "arguments")
                     ),
-                    opts.trailingComma ? b.ifBreak(",") : "",
+                    opts.trailingComma === "all" ? b.ifBreak(",") : "",
                   ]),
                   b.softline,
                   ")",


### PR DESCRIPTION
## Description

Partially improves #38. This comma is now only added when prettier is explicitly configured to do so (previously this was incorrectly following prettiers config).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
