### PR TITLE
fix: multi line export printing, improve type/var decl output

### DIFF
--- a/src/__tests__/__snapshots__/export-multiline.expected/auto.marko
+++ b/src/__tests__/__snapshots__/export-multiline.expected/auto.marko
@@ -1,0 +1,84 @@
+export type IconTypeA = (
+  "error" |
+    "information" |
+    "unknown" |
+    "success" |
+    "warning" |
+    "suggestion" |
+    "fatal" |
+    "unknown"
+);
+export type IconTypeB<T> = (
+  "error" |
+    "information" |
+    "unknown" |
+    "success" |
+    "warning" |
+    "suggestion" |
+    "fatal" |
+    "unknown" |
+    T
+);
+export type IconTypeB<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
+  Y,
+  Z,
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N
+> = true;
+export var x = (
+  "error" ||
+  "information" ||
+  "unknown" ||
+  "success" ||
+  "warning" ||
+  "suggestion" ||
+  "fatal" ||
+  "unknown"
+);
+export const y = (
+  "error" ||
+  "information" ||
+  "unknown" ||
+  "success" ||
+  "warning" ||
+  "suggestion" ||
+  "fatal" ||
+  "unknown"
+);
+export const z = true;

--- a/src/__tests__/__snapshots__/export-multiline.expected/concise.marko
+++ b/src/__tests__/__snapshots__/export-multiline.expected/concise.marko
@@ -1,0 +1,84 @@
+export type IconTypeA = (
+  "error" |
+    "information" |
+    "unknown" |
+    "success" |
+    "warning" |
+    "suggestion" |
+    "fatal" |
+    "unknown"
+);
+export type IconTypeB<T> = (
+  "error" |
+    "information" |
+    "unknown" |
+    "success" |
+    "warning" |
+    "suggestion" |
+    "fatal" |
+    "unknown" |
+    T
+);
+export type IconTypeB<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
+  Y,
+  Z,
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N
+> = true;
+export var x = (
+  "error" ||
+  "information" ||
+  "unknown" ||
+  "success" ||
+  "warning" ||
+  "suggestion" ||
+  "fatal" ||
+  "unknown"
+);
+export const y = (
+  "error" ||
+  "information" ||
+  "unknown" ||
+  "success" ||
+  "warning" ||
+  "suggestion" ||
+  "fatal" ||
+  "unknown"
+);
+export const z = true;

--- a/src/__tests__/__snapshots__/export-multiline.expected/html.marko
+++ b/src/__tests__/__snapshots__/export-multiline.expected/html.marko
@@ -1,0 +1,84 @@
+export type IconTypeA = (
+  "error" |
+    "information" |
+    "unknown" |
+    "success" |
+    "warning" |
+    "suggestion" |
+    "fatal" |
+    "unknown"
+);
+export type IconTypeB<T> = (
+  "error" |
+    "information" |
+    "unknown" |
+    "success" |
+    "warning" |
+    "suggestion" |
+    "fatal" |
+    "unknown" |
+    T
+);
+export type IconTypeB<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
+  Y,
+  Z,
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N
+> = true;
+export var x = (
+  "error" ||
+  "information" ||
+  "unknown" ||
+  "success" ||
+  "warning" ||
+  "suggestion" ||
+  "fatal" ||
+  "unknown"
+);
+export const y = (
+  "error" ||
+  "information" ||
+  "unknown" ||
+  "success" ||
+  "warning" ||
+  "suggestion" ||
+  "fatal" ||
+  "unknown"
+);
+export const z = true;

--- a/src/__tests__/__snapshots__/export-multiline.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/export-multiline.expected/with-parens.marko
@@ -1,0 +1,84 @@
+export type IconTypeA = (
+  "error" |
+    "information" |
+    "unknown" |
+    "success" |
+    "warning" |
+    "suggestion" |
+    "fatal" |
+    "unknown"
+);
+export type IconTypeB<T> = (
+  "error" |
+    "information" |
+    "unknown" |
+    "success" |
+    "warning" |
+    "suggestion" |
+    "fatal" |
+    "unknown" |
+    T
+);
+export type IconTypeB<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
+  Y,
+  Z,
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N
+> = true;
+export var x = (
+  "error" ||
+  "information" ||
+  "unknown" ||
+  "success" ||
+  "warning" ||
+  "suggestion" ||
+  "fatal" ||
+  "unknown"
+);
+export const y = (
+  "error" ||
+  "information" ||
+  "unknown" ||
+  "success" ||
+  "warning" ||
+  "suggestion" ||
+  "fatal" ||
+  "unknown"
+);
+export const z = true;

--- a/src/__tests__/__snapshots__/js-block.expected/auto.marko
+++ b/src/__tests__/__snapshots__/js-block.expected/auto.marko
@@ -1,6 +1,4 @@
-$ {
-  var name = "Frank";
-  console.log(`Hello ${name}!`);
-}
+$ var name = "Frank";
+$ console.log(`Hello ${name}!`);
 
 <div/>

--- a/src/__tests__/__snapshots__/js-block.expected/concise.marko
+++ b/src/__tests__/__snapshots__/js-block.expected/concise.marko
@@ -1,6 +1,4 @@
-$ {
-  var name = "Frank";
-  console.log(`Hello ${name}!`);
-}
+$ var name = "Frank";
+$ console.log(`Hello ${name}!`);
 
 div

--- a/src/__tests__/__snapshots__/js-block.expected/html.marko
+++ b/src/__tests__/__snapshots__/js-block.expected/html.marko
@@ -1,6 +1,4 @@
-$ {
-  var name = "Frank";
-  console.log(`Hello ${name}!`);
-}
+$ var name = "Frank";
+$ console.log(`Hello ${name}!`);
 
 <div/>

--- a/src/__tests__/__snapshots__/js-block.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/js-block.expected/with-parens.marko
@@ -1,6 +1,4 @@
-$ {
-  var name = "Frank";
-  console.log(`Hello ${name}!`);
-}
+$ var name = "Frank";
+$ console.log(`Hello ${name}!`);
 
 <div/>

--- a/src/__tests__/__snapshots__/scriptlet-block.expected/auto.marko
+++ b/src/__tests__/__snapshots__/scriptlet-block.expected/auto.marko
@@ -1,4 +1,2 @@
-$ {
-  var bgColor = getRandomColor();
-  var textColor = isLight(bgColor) ? "black" : "white";
-}
+$ var bgColor = getRandomColor();
+$ var textColor = isLight(bgColor) ? "black" : "white";

--- a/src/__tests__/__snapshots__/scriptlet-block.expected/concise.marko
+++ b/src/__tests__/__snapshots__/scriptlet-block.expected/concise.marko
@@ -1,4 +1,2 @@
-$ {
-  var bgColor = getRandomColor();
-  var textColor = isLight(bgColor) ? "black" : "white";
-}
+$ var bgColor = getRandomColor();
+$ var textColor = isLight(bgColor) ? "black" : "white";

--- a/src/__tests__/__snapshots__/scriptlet-block.expected/html.marko
+++ b/src/__tests__/__snapshots__/scriptlet-block.expected/html.marko
@@ -1,4 +1,2 @@
-$ {
-  var bgColor = getRandomColor();
-  var textColor = isLight(bgColor) ? "black" : "white";
-}
+$ var bgColor = getRandomColor();
+$ var textColor = isLight(bgColor) ? "black" : "white";

--- a/src/__tests__/__snapshots__/scriptlet-block.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/scriptlet-block.expected/with-parens.marko
@@ -1,4 +1,2 @@
-$ {
-  var bgColor = getRandomColor();
-  var textColor = isLight(bgColor) ? "black" : "white";
-}
+$ var bgColor = getRandomColor();
+$ var textColor = isLight(bgColor) ? "black" : "white";

--- a/src/__tests__/__snapshots__/scriptlet-multi-line.expected/auto.marko
+++ b/src/__tests__/__snapshots__/scriptlet-multi-line.expected/auto.marko
@@ -1,5 +1,3 @@
-$ {
-  var foo = {
-    bar: "foo",
-  };
-}
+$ var foo = {
+  bar: "foo",
+};

--- a/src/__tests__/__snapshots__/scriptlet-multi-line.expected/concise.marko
+++ b/src/__tests__/__snapshots__/scriptlet-multi-line.expected/concise.marko
@@ -1,5 +1,3 @@
-$ {
-  var foo = {
-    bar: "foo",
-  };
-}
+$ var foo = {
+  bar: "foo",
+};

--- a/src/__tests__/__snapshots__/scriptlet-multi-line.expected/html.marko
+++ b/src/__tests__/__snapshots__/scriptlet-multi-line.expected/html.marko
@@ -1,5 +1,3 @@
-$ {
-  var foo = {
-    bar: "foo",
-  };
-}
+$ var foo = {
+  bar: "foo",
+};

--- a/src/__tests__/__snapshots__/scriptlet-multi-line.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/scriptlet-multi-line.expected/with-parens.marko
@@ -1,5 +1,3 @@
-$ {
-  var foo = {
-    bar: "foo",
-  };
-}
+$ var foo = {
+  bar: "foo",
+};

--- a/src/__tests__/__snapshots__/scriptlets.expected/auto.marko
+++ b/src/__tests__/__snapshots__/scriptlets.expected/auto.marko
@@ -1,17 +1,13 @@
 $ console.log("hello");
-$ {
-  console.log("a");
-  console.log("b");
-}
-$ {
-  console.log("a");
-  console.log("b");
-  console.log("c");
-  console.log("d");
-  console.log("e");
-  console.log("f");
-  console.log("g");
-}
+$ console.log("a");
+$ console.log("b");
+$ console.log("a");
+$ console.log("b");
+$ console.log("c");
+$ console.log("d");
+$ console.log("e");
+$ console.log("f");
+$ console.log("g");
 $ console.log(
   new Map([
     ["a", 1],

--- a/src/__tests__/__snapshots__/scriptlets.expected/concise.marko
+++ b/src/__tests__/__snapshots__/scriptlets.expected/concise.marko
@@ -1,17 +1,13 @@
 $ console.log("hello");
-$ {
-  console.log("a");
-  console.log("b");
-}
-$ {
-  console.log("a");
-  console.log("b");
-  console.log("c");
-  console.log("d");
-  console.log("e");
-  console.log("f");
-  console.log("g");
-}
+$ console.log("a");
+$ console.log("b");
+$ console.log("a");
+$ console.log("b");
+$ console.log("c");
+$ console.log("d");
+$ console.log("e");
+$ console.log("f");
+$ console.log("g");
 $ console.log(
   new Map([
     ["a", 1],

--- a/src/__tests__/__snapshots__/scriptlets.expected/html.marko
+++ b/src/__tests__/__snapshots__/scriptlets.expected/html.marko
@@ -1,17 +1,13 @@
 $ console.log("hello");
-$ {
-  console.log("a");
-  console.log("b");
-}
-$ {
-  console.log("a");
-  console.log("b");
-  console.log("c");
-  console.log("d");
-  console.log("e");
-  console.log("f");
-  console.log("g");
-}
+$ console.log("a");
+$ console.log("b");
+$ console.log("a");
+$ console.log("b");
+$ console.log("c");
+$ console.log("d");
+$ console.log("e");
+$ console.log("f");
+$ console.log("g");
 $ console.log(
   new Map([
     ["a", 1],

--- a/src/__tests__/__snapshots__/scriptlets.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/scriptlets.expected/with-parens.marko
@@ -1,17 +1,13 @@
 $ console.log("hello");
-$ {
-  console.log("a");
-  console.log("b");
-}
-$ {
-  console.log("a");
-  console.log("b");
-  console.log("c");
-  console.log("d");
-  console.log("e");
-  console.log("f");
-  console.log("g");
-}
+$ console.log("a");
+$ console.log("b");
+$ console.log("a");
+$ console.log("b");
+$ console.log("c");
+$ console.log("d");
+$ console.log("e");
+$ console.log("f");
+$ console.log("g");
 $ console.log(
   new Map([
     ["a", 1],

--- a/src/__tests__/__snapshots__/static.expected/auto.marko
+++ b/src/__tests__/__snapshots__/static.expected/auto.marko
@@ -1,17 +1,13 @@
 static console.log("hello");
-static {
-  console.log("a");
-  console.log("b");
-}
-static {
-  console.log("a");
-  console.log("b");
-  console.log("c");
-  console.log("d");
-  console.log("e");
-  console.log("f");
-  console.log("g");
-}
+static console.log("a");
+static console.log("b");
+static console.log("a");
+static console.log("b");
+static console.log("c");
+static console.log("d");
+static console.log("e");
+static console.log("f");
+static console.log("g");
 static console.log(
   new Map([
     ["a", 1],

--- a/src/__tests__/__snapshots__/static.expected/concise.marko
+++ b/src/__tests__/__snapshots__/static.expected/concise.marko
@@ -1,17 +1,13 @@
 static console.log("hello");
-static {
-  console.log("a");
-  console.log("b");
-}
-static {
-  console.log("a");
-  console.log("b");
-  console.log("c");
-  console.log("d");
-  console.log("e");
-  console.log("f");
-  console.log("g");
-}
+static console.log("a");
+static console.log("b");
+static console.log("a");
+static console.log("b");
+static console.log("c");
+static console.log("d");
+static console.log("e");
+static console.log("f");
+static console.log("g");
 static console.log(
   new Map([
     ["a", 1],

--- a/src/__tests__/__snapshots__/static.expected/html.marko
+++ b/src/__tests__/__snapshots__/static.expected/html.marko
@@ -1,17 +1,13 @@
 static console.log("hello");
-static {
-  console.log("a");
-  console.log("b");
-}
-static {
-  console.log("a");
-  console.log("b");
-  console.log("c");
-  console.log("d");
-  console.log("e");
-  console.log("f");
-  console.log("g");
-}
+static console.log("a");
+static console.log("b");
+static console.log("a");
+static console.log("b");
+static console.log("c");
+static console.log("d");
+static console.log("e");
+static console.log("f");
+static console.log("g");
 static console.log(
   new Map([
     ["a", 1],

--- a/src/__tests__/__snapshots__/static.expected/with-parens.marko
+++ b/src/__tests__/__snapshots__/static.expected/with-parens.marko
@@ -1,17 +1,13 @@
 static console.log("hello");
-static {
-  console.log("a");
-  console.log("b");
-}
-static {
-  console.log("a");
-  console.log("b");
-  console.log("c");
-  console.log("d");
-  console.log("e");
-  console.log("f");
-  console.log("g");
-}
+static console.log("a");
+static console.log("b");
+static console.log("a");
+static console.log("b");
+static console.log("c");
+static console.log("d");
+static console.log("e");
+static console.log("f");
+static console.log("g");
 static console.log(
   new Map([
     ["a", 1],

--- a/src/__tests__/fixtures/export-multiline.marko
+++ b/src/__tests__/fixtures/export-multiline.marko
@@ -1,0 +1,9 @@
+export type IconTypeA = "error" | "information" | "unknown" | "success" | "warning" | "suggestion" | "fatal" | "unknown";
+
+export type IconTypeB<T> = "error" | "information" | "unknown" | "success" | "warning" | "suggestion" | "fatal" | "unknown" | T;
+
+export type IconTypeB<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, A, B, C, D, E, F, G, H, I, J, K, L, M, N> = true;
+
+export var x = "error" || "information" || "unknown" || "success" || "warning" || "suggestion" || "fatal" || "unknown";
+
+export const y = "error" || "information" || "unknown" || "success" || "warning" || "suggestion" || "fatal" || "unknown", z = true;

--- a/src/utils/with-block-if-needed.ts
+++ b/src/utils/with-block-if-needed.ts
@@ -7,34 +7,25 @@ import { getOriginalCodeForNode } from "./get-original-code";
 const { builders: b } = doc;
 
 export default function withBlockIfNeeded(
-  nodes: t.Statement[],
+  node: t.Statement,
   opts: ParserOptions,
-  docs: Doc[]
+  docs: Doc
 ) {
-  let count = 0;
-  let statement!: t.Statement;
-  for (const node of nodes) {
-    if (node.type === "EmptyStatement") continue;
-    if (++count > 1) break;
-    statement = node;
-  }
-
   if (
-    count > 1 ||
-    (!enclosedNodeTypeReg.test(statement.type) &&
-      outerCodeMatches(
-        format(getOriginalCodeForNode(opts, statement), {
-          ...opts,
-          printWidth: 0,
-          parser: opts.markoScriptParser,
-        }).trim(),
-        /[\n\r]/y
-      ))
+    !enclosedNodeTypeReg.test(node.type) &&
+    outerCodeMatches(
+      format(getOriginalCodeForNode(opts, node), {
+        ...opts,
+        printWidth: 0,
+        parser: opts.markoScriptParser,
+      }).trim(),
+      /[\n\r]/y
+    )
   ) {
-    return [
-      b.indent([b.ifBreak(["{", b.line]), b.join(b.hardline, docs)]),
+    return b.group([
+      b.indent([b.ifBreak(["{", b.line]), docs]),
       b.ifBreak([b.line, "}"]),
-    ];
+    ]);
   }
 
   return docs;


### PR DESCRIPTION
## Description

See https://github.com/marko-js/htmljs-parser/issues/166

Fixes printing of `export` statements to ensure they align with what the htmljs-parser expects.
In the htmljs-parser newlines terminate statements meaning code like the following is invalid:
```
export const x =
  1;
```
with the work around being to wrap things in braces, eg
```
export const x = (
  1
 );
```

This PR automatically wraps these statements in parenthesis if needed.

This logic has also been used to improve the output for `static` and `$` scriptlets which now prefer to avoid outputting the `{ block }` syntax in more cases.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
