### PR TITLE
feat: print async shorthand methods

### DIFF
--- a/.changeset/async-attr-method-shorthand.md
+++ b/.changeset/async-attr-method-shorthand.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-marko": minor
+---
+
+Print the `async` shorthand method modifier, eg `<button async onClick() { await save() }>`.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:update": "vitest run --update"
   },
   "dependencies": {
-    "htmljs-parser": "^5.12.1"
+    "htmljs-parser": "^5.14.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       htmljs-parser:
-        specifier: ^5.12.1
-        version: 5.12.1
+        specifier: ^5.14.0
+        version: 5.14.0
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.7.0
@@ -819,8 +819,8 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  htmljs-parser@5.12.1:
-    resolution: {integrity: sha512-QnHLg5SWqoH5o8MD4iOWJFtdKSS2lXxtNgyznFXvEeeCK0CTi6URdYtFGkFGDANdq8RZzkuc91KaBgLx2WAhSA==}
+  htmljs-parser@5.14.0:
+    resolution: {integrity: sha512-cGHMvzufiWAcQl11UM8HwxxpFkVicgtJ5RniyFHTClT0WfwMWSxAc7QMAlqpKet+xTsrr7QOOeShOENBMvCPVg==}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -1798,7 +1798,7 @@ snapshots:
       '@luxass/strip-json-comments': 1.4.0
       complain: 1.6.1
       he: 1.2.0
-      htmljs-parser: 5.12.1
+      htmljs-parser: 5.14.0
       jsesc: 3.1.0
       kleur: 4.1.5
       lasso-package-root: 1.0.1
@@ -2353,7 +2353,7 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  htmljs-parser@5.12.1: {}
+  htmljs-parser@5.14.0: {}
 
   human-id@4.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+# htmljs-parser is first-party: the release-age gate guards against a
+# compromised third-party publish, which is not the threat model here.
+minimumReleaseAgeExclude:
+  - htmljs-parser

--- a/src/__tests__/fixtures/attr-gt-value/__snapshots__/auto.expected.marko
+++ b/src/__tests__/fixtures/attr-gt-value/__snapshots__/auto.expected.marko
@@ -1,3 +1,3 @@
-<if=(current >= 0)/>
+<if=current >= 0/>
 
 <if=(current > 0)/>

--- a/src/__tests__/fixtures/attr-gt-value/__snapshots__/html.expected.marko
+++ b/src/__tests__/fixtures/attr-gt-value/__snapshots__/html.expected.marko
@@ -1,3 +1,3 @@
-<if=(current >= 0)/>
+<if=current >= 0/>
 
 <if=(current > 0)/>

--- a/src/__tests__/fixtures/attr-method-async/__snapshots__/auto.expected.marko
+++ b/src/__tests__/fixtures/attr-method-async/__snapshots__/auto.expected.marko
@@ -1,0 +1,19 @@
+<button async onClick() {
+  await save();
+}>
+  x
+</button>
+
+<button async onClick<T extends Event>(event: T) {
+  await save(event);
+}>
+  x
+</button>
+
+<custom-tag async (value) {
+  await save(value);
+}/>
+
+<custom-tag async (value) {
+  await save(value);
+}/>

--- a/src/__tests__/fixtures/attr-method-async/__snapshots__/concise.expected.marko
+++ b/src/__tests__/fixtures/attr-method-async/__snapshots__/concise.expected.marko
@@ -1,0 +1,15 @@
+button async onClick() {
+  await save();
+} -- x
+
+button async onClick<T extends Event>(event: T) {
+  await save(event);
+} -- x
+
+custom-tag async (value) {
+  await save(value);
+}
+
+custom-tag async (value) {
+  await save(value);
+}

--- a/src/__tests__/fixtures/attr-method-async/__snapshots__/html.expected.marko
+++ b/src/__tests__/fixtures/attr-method-async/__snapshots__/html.expected.marko
@@ -1,0 +1,19 @@
+<button async onClick() {
+  await save();
+}>
+  x
+</button>
+
+<button async onClick<T extends Event>(event: T) {
+  await save(event);
+}>
+  x
+</button>
+
+<custom-tag async (value) {
+  await save(value);
+}/>
+
+<custom-tag async (value) {
+  await save(value);
+}/>

--- a/src/__tests__/fixtures/attr-method-async/template.marko
+++ b/src/__tests__/fixtures/attr-method-async/template.marko
@@ -1,0 +1,11 @@
+<button async onClick() {await save()
+}>x</button>
+
+<button async onClick<T extends Event>(event: T) {await save(event)
+}>x</button>
+
+<custom-tag async (value) {await save(value)
+}/>
+
+<custom-tag async(value) {await save(value)
+}/>

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,12 @@ const embedHandlers: EmbedHandlers = {
     const { node } = path;
     const name = read(node.name, opts);
     if (!(node.args || node.value)) return name;
-    const attrDoc: Doc[] = [name];
+    // A default attribute method is printed flush against the tag name, so an
+    // `async` before it has to bring its own leading space.
+    const attrDoc: Doc[] =
+      node.value?.type === NodeType.AttrMethod && node.value.async
+        ? [isDefaultAttr(node) ? " async " : "async ", name]
+        : [name];
 
     if (node.args && !isEmpty(node.args.value, opts)) {
       const argsDoc = await argsToDoc(node.args, opts, toDoc);
@@ -362,8 +367,12 @@ const embedHandlers: EmbedHandlers = {
 
     if (node.value) {
       if (node.value.type === NodeType.AttrMethod) {
+        // Rebuilt from the type params since the keyword prints before the
+        // name, but kept here or an `await` in the body fails to parse.
+        const { async, typeParams, params, end } = node.value;
+        const source = read({ start: (typeParams ?? params).start, end }, opts);
         const attrMethodDoc = await toDoc(
-          `function${read(node.value, opts)}`,
+          `${async ? "async " : ""}function${source}`,
           exprParse,
         );
 
@@ -372,7 +381,10 @@ const embedHandlers: EmbedHandlers = {
           attrMethodDoc.length &&
           typeof attrMethodDoc[0] === "string"
         ) {
-          attrMethodDoc[0] = attrMethodDoc[0].replace(/^function\s*/, "");
+          attrMethodDoc[0] = attrMethodDoc[0].replace(
+            /^(?:async\s+)?function\s*/,
+            "",
+          );
           attrDoc.push(attrMethodDoc);
           /* c8 ignore start */
         } else {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -267,6 +267,7 @@ export namespace Node {
     typeParams: undefined | Ranges.Value;
     params: Range;
     body: Range;
+    async: boolean;
   }
 
   export interface AttrSpread extends Ranges.Value {
@@ -744,6 +745,7 @@ class Builder {
       typeParams: range.typeParams,
       params: range.params,
       body: range.body,
+      async: range.async,
       start: range.start,
       end: range.end,
     };


### PR DESCRIPTION
Prints htmljs-parser's new `async` method modifier, eg `<button async onClick() { await save() }>`. The function is rebuilt with the keyword before parsing, otherwise an `await` in the body fails to parse and the method falls back to being printed verbatim.

The first commit bumps htmljs-parser to 5.14 on its own: 5.13 recognizes a whitespace preceded `>=` as unambiguous, so `isValidAttrValue` no longer asks for the parens the attr-gt-value snapshot recorded.