### PR TITLE
agent-feedback: comment, placeholder and escaping output defects

### DIFF
--- a/agent-feedback/items/2026-08-21-block-comment-glued-to-inline-sibling.md
+++ b/agent-feedback/items/2026-08-21-block-comment-glued-to-inline-sibling.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: med
+site: src/index.ts › printBody
+---
+
+# Keep a separator before a `/* */` body comment so it stays a comment
+
+In `printBody` a non-line comment is marked `inlineChild` whenever the preceding child was inline, so a `/* */` comment that followed a tag or a placeholder is pushed into the same fill with no separator at all. htmljs-parser only starts a comment at a content boundary, so the joined result re-parses as text and the comment is rendered into the page: `<div>\n  <span/>\n  /* c */\n</div>` compiles to `_html("<div><span></span></div>")` and formats to `<div><span/>/* c */</div>`, which compiles to `_html("<div><span></span>/* c */</div>")`. The rewrite is idempotent, so `--check` goes green on the corrupted file and nothing reports the loss. The `<!-- -->` form survives because its delimiter needs no boundary, and the same input in concise mode is left alone, so the fix is narrow: when the comment is `/* */` and the fill does not already end in a line, keep a separator (or leave it out of the fill). The 4.0.8 note "only consider a comment inline text if it was preceded by inline text" is the rule that wants tightening — a `Tag` or `Placeholder` sibling is inline but is not text.
+
+Check: `printf '<div>\n  <span/>\n  /* c */\n</div>\n' > /tmp/x.marko && pnpm run build && pnpm exec prettier --write --plugin ./dist/index.mjs /tmp/x.marko` prints `<div><span/>/* c */</div>`, whose compiled markup is `<div><span></span>/* c */</div>` against the input's `<div><span></span></div>`; expect the comment to stay a comment.

--- a/agent-feedback/items/2026-08-21-concise-text-wrap-after-placeholder.md
+++ b/agent-feedback/items/2026-08-21-concise-text-wrap-after-placeholder.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: med
+site: src/index.ts › printBody
+---
+
+# Do not break a concise `--` text line directly after a placeholder
+
+`printBody` turns every space in a `Text` child into a `b.line`, and `wrapConciseText` lets the fill break at any of them, but in a concise `--` body the continuation newline is not always worth a space. htmljs-parser reports `div --\n  a\n  b` as `Text "a\n"` + `Text "b"`, which the compiler collapses to `a b`, while `div --\n  a ${1}\n  b` becomes `Text "a "` + `Placeholder` + `Text "\n"` + `Text "b"` and the stranded whitespace-only text node is dropped, giving `a 1b`. Choosing that break therefore changes the page: at the default `printWidth` of 80, `div\n  -- <21 short words> ${1} b` compiles to `... 1 b` and its formatted form compiles to `... 1b`, and the next pass collapses the file to `${1}b`, so the printer is not idempotent either. Either keep the space visible at that break (the `${" "}` machinery already exists) or refuse to break a concise fill immediately after a `Placeholder`; the same wrap is safe in HTML mode, where `<div>a ${1}\n  b</div>` still compiles to `a 1 b`.
+
+Check: format `div\n  -- w0 w1 w2 w3 w4 w5 w6 w7 w8 w9 w10 w11 w12 w13 w14 w15 w16 w17 w18 w19 w20 ${1} b` and compile before and after with `@marko/compiler`; today the emitted markup goes from `w20 1 b` to `w20 1b` and a second format pass rewrites `${1}\n  b` to `${1}b`, and both should be no-ops.

--- a/agent-feedback/items/2026-08-21-expose-package-json-export.md
+++ b/agent-feedback/items/2026-08-21-expose-package-json-export.md
@@ -1,0 +1,12 @@
+---
+type: cleanup
+impact: low
+effort: low
+site: package.json › exports
+---
+
+# Expose `./package.json` from the exports map
+
+The exports map lists only `.`, so `require("prettier-plugin-marko/package.json")` — the usual way to report which plugin build a format run used — throws `ERR_PACKAGE_PATH_NOT_EXPORTED`, and `src/index.ts` exports no `version` either. Every neighbour in the same one-liner resolves — `prettier` covers it with a `"./*"` wildcard and `@marko/runtime-tags` maps `"./package.json": "./package.json"` outright — so a tool that prints its toolchain versions has to special-case this package or read the file by hand. The same item is already filed against `htmljs-parser`, which has the identical one-line gap, so fixing both together keeps the chain consistent.
+
+Check: `node -e "console.log(require('prettier-plugin-marko/package.json').version)"` from a project with the plugin installed prints `Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports"`; expect it to print the version.

--- a/agent-feedback/items/2026-08-21-text-backslash-doubling.md
+++ b/agent-feedback/items/2026-08-21-text-backslash-doubling.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: med
+site: src/index.ts › printHandlers[NodeType.Text]
+---
+
+# Escape only the backslashes that could swallow a following placeholder
+
+The `Text` handler is `read(path.node, opts).replace(/\\/g, "\\\\")`, so it doubles every backslash in text content, but htmljs-parser only consumes a backslash as an escape when the run leads into `${` or `$!{`: parsing `<div>a\b</div>` yields one `Text` range spanning `a\b`, while `<div>\\${x}</div>` yields `Text` `\` plus a live `Placeholder`. Doubling unconditionally therefore has no fixed point — a Windows path, a LaTeX fragment or a regexp in prose grows 1, 2, 4, 8 backslashes over successive `--write` runs, so `prettier --check` can never go green on that file — and it is not merely cosmetic: `@marko/compiler` emits `_html("<div>a\\b</div>")` before and `_html("<div>a\\\\b</div>")` after, so the page really renders the extra backslash. The escape only needs to cover a backslash run immediately preceding a placeholder boundary, which is what `src/__tests__/fixtures/placeholders-body-double-escaped` pins; `text-content-backslashes` looks like coverage but its body is inside `<html-script>`, which `hasTagParser` routes to `embedHandlers` so no `Text` node reaches this handler, leaving plain text content with no fixture at all. Concise `--` bodies and `<pre>` are hit the same way — `hasPreservedText` does not exempt them; attribute strings and `<script>`/`<style>` are not.
+
+Check: `printf '<p>Path: C:\\Users\\dev</p>\n' > /tmp/x.marko && pnpm run build && pnpm exec prettier --write --plugin ./dist/index.mjs /tmp/x.marko` run three times prints `C:\\Users\\dev`, then `C:\\\\Users\\\\dev`, then `C:\\\\\\\\Users\\\\\\\\dev`; expect the second run to leave the file byte-identical to the first.

--- a/agent-feedback/items/2026-08-21-visible-space-beside-a-comment.md
+++ b/agent-feedback/items/2026-08-21-visible-space-beside-a-comment.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: med
+site: src/utils/visible-space.ts › ensureVisibleSpace
+---
+
+# Stop turning the whitespace beside a comment into `${" "}`
+
+`printBody` folds a block comment into the current inline fill whenever the previous child was inline, and `ensureVisibleSpace` then rewrites a leading or trailing `b.line` of that fill into `${" "}` so the space survives a re-parse. Whitespace next to a Marko comment is not significant — the comment is erased at compile time — so the escape materialises a space that was never rendered: `<div>\n  <!-- c -->\n  x\n</div>` compiles to `_html("<div>x</div>")` and its formatted form `<div>\n  <!-- c -->\n  ${" "}x\n</div>` compiles to `_html("<div> x</div>")`, with the mirror shape (`x` then the comment) yielding `<div>x </div>`. The one-line form `<div><!--c-->text</div>` is worse to review because pass 1 is faithful and pass 2 introduces the space, so a clean diff turns into a changed page on the next contributor's format run. The guard belongs where the fill boundary is computed: a `b.line` that only ever separated content from a comment must stay a `b.line`. A related shape shows the escape is unsafe after any literal `<` too — `<div>< </div>` becomes `<div><${" "}</div>`, where `<` + `${` reads as a dynamic-tag opener and `@marko/compiler` fails with `EOF reached while parsing open tag` while prettier exits 0.
+
+Check: format `<div>\n  <!-- c -->\n  x\n</div>` with `pnpm exec prettier --plugin ./dist/index.mjs --parser marko` and compile input and output with `@marko/compiler`; today the emitted markup goes from `<div>x</div>` to `<div> x</div>`, and it should be byte-identical.


### PR DESCRIPTION
Five new items, four of them cases where formatting changes meaning or loses information: a `/* */` body comment loses the separator that keeps it a comment, a concise `--` text line breaks directly after a placeholder, whitespace beside a comment becomes `${" "}`, and backslash escaping is wider than the ones that could swallow a following placeholder.

The last exposes `./package.json` from the exports map.
